### PR TITLE
Fix the DateTimeOffset

### DIFF
--- a/lib/odata/properties/date_time.rb
+++ b/lib/odata/properties/date_time.rb
@@ -9,7 +9,7 @@ module OData
           nil
         else
           begin
-            ::DateTime.strptime(@value, '%Y-%m-%dT%H:%M:%S.%L')
+            ::DateTime.strptime(@value, strptime_format)
           rescue ArgumentError
             ::DateTime.parse(@value)
           end
@@ -36,11 +36,16 @@ module OData
 
       private
 
+      def strptime_format
+        '%Y-%m-%dT%H:%M:%S.%L'
+      end
+
       def validate(value)
         begin
           return if value.nil? && allows_nil?
           return if value.is_a?(::DateTime)
-          ::DateTime.strptime(value, '%Y-%m-%dT%H:%M:%S.%L')
+
+          ::DateTime.strptime(value, strptime_format)
         rescue
           raise ArgumentError, 'Value is not a date time format that can be parsed'
         end
@@ -48,9 +53,10 @@ module OData
 
       def parse_value(value)
         return value if value.nil? && allows_nil?
+
         parsed_value = value
         parsed_value = ::DateTime.parse(value) unless value.is_a?(::DateTime)
-        parsed_value.strftime('%Y-%m-%dT%H:%M:%S.%L')
+        parsed_value.strftime(strptime_format)
       end
     end
   end

--- a/lib/odata/properties/date_time_offset.rb
+++ b/lib/odata/properties/date_time_offset.rb
@@ -5,10 +5,10 @@ module OData
       # Returns the property value, properly typecast
       # @return [DateTime,nil]
       def value
-        if (@value.nil? || @value.empty?) && allow_nil?
+        if (@value.nil? || @value.empty?) && allows_nil?
           nil
         else
-          ::DateTime.strptime(@value, '%Y-%m-%dT%H:%M:%S.%LZ%:z')
+          ::DateTime.strptime(@value, '%Y-%m-%dT%H:%M:%S%:z')
         end
       end
 
@@ -27,15 +27,17 @@ module OData
       private
 
       def validate(value)
-        unless value.is_a?(::DateTime)
+        unless value.is_a?(::DateTime) || (value.nil? || value.empty?) && allows_nil?
           raise ArgumentError, 'Value is not a date time format that can be parsed'
         end
       end
 
       def parse_value(value)
+        return value if value.nil? && allows_nil?
+
         parsed_value = value
         parsed_value = ::DateTime.parse(value) unless value.is_a?(::DateTime)
-        parsed_value.strftime('%Y-%m-%dT%H:%M:%S.%LZ%:z')
+        parsed_value.strftime('%Y-%m-%dT%H:%M:%S%:z')
       end
     end
   end

--- a/lib/odata/properties/date_time_offset.rb
+++ b/lib/odata/properties/date_time_offset.rb
@@ -1,23 +1,7 @@
 module OData
   module Properties
     # Defines the DateTimeOffset OData type.
-    class DateTimeOffset < OData::Property
-      # Returns the property value, properly typecast
-      # @return [DateTime,nil]
-      def value
-        if (@value.nil? || @value.empty?) && allows_nil?
-          nil
-        else
-          ::DateTime.strptime(@value, '%Y-%m-%dT%H:%M:%S%:z')
-        end
-      end
-
-      # Sets the property value
-      # @params new_value [DateTime]
-      def value=(new_value)
-        validate(new_value)
-        @value = parse_value(new_value)
-      end
+    class DateTimeOffset < OData::Properties::DateTime
 
       # The OData type name
       def type
@@ -26,18 +10,8 @@ module OData
 
       private
 
-      def validate(value)
-        unless value.is_a?(::DateTime) || (value.nil? || value.empty?) && allows_nil?
-          raise ArgumentError, 'Value is not a date time format that can be parsed'
-        end
-      end
-
-      def parse_value(value)
-        return value if value.nil? && allows_nil?
-
-        parsed_value = value
-        parsed_value = ::DateTime.parse(value) unless value.is_a?(::DateTime)
-        parsed_value.strftime('%Y-%m-%dT%H:%M:%S%:z')
+      def strptime_format
+        '%Y-%m-%dT%H:%M:%S%:z'
       end
     end
   end

--- a/spec/odata/properties/date_time_offset_spec.rb
+++ b/spec/odata/properties/date_time_offset_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe OData::Properties::DateTimeOffset do
-  let(:subject) { OData::Properties::DateTimeOffset.new('DateTime', '2000-01-01T16:00:00.000Z-09:00') }
-  let(:new_datetime) { DateTime.strptime('2004-05-01T14:32:00.000Z+02:00', '%Y-%m-%dT%H:%M:%S.%LZ%:z') }
+  let(:subject) { OData::Properties::DateTimeOffset.new('DateTime', '2002-10-10T17:00:00Z') }
+  let(:new_datetime) { DateTime.strptime('2015-01-08T22:11:58Z', '%Y-%m-%dT%H:%M:%S%:z') }
 
   it { expect(subject.type).to eq('Edm.DateTimeOffset') }
-  it { expect(subject.value).to eq(DateTime.strptime('2000-01-01T16:00:00.000Z-09:00', '%Y-%m-%dT%H:%M:%S.%LZ%:z')) }
+  it { expect(subject.value).to eq(DateTime.strptime('2002-10-10T17:00:00Z', '%Y-%m-%dT%H:%M:%S%:z')) }
 
   it { expect {subject.value = 'bad'}.to raise_error(ArgumentError) }
 
@@ -13,4 +13,16 @@ describe OData::Properties::DateTimeOffset do
     subject.value = new_datetime
     subject.value
   }.call).to eq(new_datetime) }
+
+  it { expect(lambda {
+    subject.value = nil
+  }).not_to raise_error }
+
+  context "with the allows_nil option set to false" do
+    let(:subject) { OData::Properties::DateTimeOffset.new('DateTime', '2002-10-10T17:00:00Z', allows_nil: false) }
+
+    it { expect(lambda {
+      subject.value = nil
+    }).to raise_error(ArgumentError) }
+  end
 end

--- a/spec/odata/properties/date_time_spec.rb
+++ b/spec/odata/properties/date_time_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe OData::Properties::DateTime do
-  let(:subject) { OData::Properties::DateTime.new('DateTime', '2000-01-01T16:00:00.000') }
+  let(:subject) { OData::Properties::DateTime.new('DateTime', "datetime'2000-12-12T12:00'") }
   let(:new_datetime) { DateTime.strptime('2004-05-01T14:32:00.000', '%Y-%m-%dT%H:%M:%S.%L') }
 
   it { expect(subject.type).to eq('Edm.DateTime') }
-  it { expect(subject.value).to eq(DateTime.parse('2000-01-01T16:00:00.000')) }
+  it { expect(subject.value).to eq(DateTime.parse("datetime'2000-12-12T12:00'")) }
 
-  it { expect(subject.url_value).to eq("datetime'2000-01-01T16:00:00+00:00'")}
+  it { expect(subject.url_value).to eq("datetime'2000-12-12T12:00:00+00:00'")}
 
   it { expect {subject.value = 'bad'}.to raise_error(ArgumentError) }
 


### PR DESCRIPTION
The DateTimeOffset implementation did not fit the specification for the OData 2.0 specification.

There was a typo `allow_nil` vs `allows_nil`

The implementation to allow nil values was not complete